### PR TITLE
UX: Display confirmation message after subscribing

### DIFF
--- a/assets/javascripts/discourse/connectors/top-notices/newsletter-banner.hbs
+++ b/assets/javascripts/discourse/connectors/top-notices/newsletter-banner.hbs
@@ -1,23 +1,35 @@
 {{#if this.showBanner}}
   <aside class="newsletter-subscription-banner">
     <div class="banner-text">
-      <h2>{{i18n "discourse_newsletter_integration.banner.heading"}}
-        {{emoji "love_letter"}}</h2>
-      <p class="banner-description">
-        {{i18n "discourse_newsletter_integration.banner.description"}}
-      </p>
+      {{#if this.subscribed}}
+        <h3>{{i18n "discourse_newsletter_integration.banner.thank_you"}}
+          {{emoji "tada"}}</h3>
+        <p class="banner-description">
+          {{html-safe
+            (i18n
+              "discourse_newsletter_integration.banner.added_to_newsletter"
+              preferencesUrl=(get-url "/my/preferences/emails")
+            )
+          }}
+        </p>
+      {{else}}
+        <h2>{{i18n "discourse_newsletter_integration.banner.heading"}}
+          {{emoji "love_letter"}}</h2>
+        <p class="banner-description">
+          {{i18n "discourse_newsletter_integration.banner.description"}}
+        </p>
+      {{/if}}
     </div>
     <div class="banner-controls">
       <DButton @icon="times" @class="close-btn" @action={{action "dismiss"}} />
-      <DButton
-        @class="btn-primary subscribe-btn"
-        @label="discourse_newsletter_integration.banner.subscribe"
-        @action={{action "subscribe"}}
-        @disabled={{this.disableControls}}
-      />
-      <a class="manage-preferences" href={{get-url "/my/preferences/emails"}}>
-        {{i18n "discourse_newsletter_integration.banner.manage_preferences"}}
-      </a>
+      {{#unless this.subscribed}}
+        <DButton
+          @class="btn-primary subscribe-btn"
+          @label="discourse_newsletter_integration.banner.subscribe"
+          @action={{action "subscribe"}}
+          @disabled={{this.disableControls}}
+        />
+      {{/unless}}
     </div>
   </aside>
 {{/if}}

--- a/assets/javascripts/discourse/connectors/top-notices/newsletter-banner.js
+++ b/assets/javascripts/discourse/connectors/top-notices/newsletter-banner.js
@@ -8,8 +8,10 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default class NewsletterBanner extends Component {
   @service site;
   @service currentUser;
+
   @tracked disableControls = false;
   @tracked dismissed = false;
+  @tracked subscribed = false;
 
   get showBanner() {
     return (
@@ -23,26 +25,26 @@ export default class NewsletterBanner extends Component {
   async subscribe() {
     this.disableControls = true;
 
-    let succeeded = true;
     try {
       await ajax("/newsletter-integration/subscriptions", { type: "POST" });
+      this.subscribed = true;
     } catch (e) {
-      succeeded = false;
       popupAjaxError(e);
     }
 
-    this.dismissed = succeeded;
     this.disableControls = false;
   }
 
   @action
   async dismiss() {
     this.dismissed = true;
-    try {
-      await ajax("/newsletter-integration/subscriptions", { type: "DELETE" });
-    } catch (e) {
-      this.dismissed = false;
-      popupAjaxError(e);
+    if (!this.subscribed) {
+      try {
+        await ajax("/newsletter-integration/subscriptions", { type: "DELETE" });
+      } catch (e) {
+        this.dismissed = false;
+        popupAjaxError(e);
+      }
     }
   }
 }

--- a/assets/stylesheets/common/banner.scss
+++ b/assets/stylesheets/common/banner.scss
@@ -21,7 +21,6 @@
     flex: 1 0 auto;
     flex-direction: column;
     align-items: end;
-    justify-content: space-between;
 
     .close-btn {
       padding: 0;
@@ -37,8 +36,9 @@
       }
     }
 
-    .manage-preferences {
-      font-size: var(--font-down-2);
+    .subscribe-btn {
+      margin-top: auto;
+      margin-bottom: auto;
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,6 +7,9 @@ en:
         manage_preferences: "Manage preferences"
         description: |
           Stay informed with the latest updates, news, and discussions by subscribing to our community newsletter.
+        thank_you: "Thank you! You've been added to our newsletter!"
+        added_to_newsletter: |
+          If you change your mind, you can always update your subscription in your <a href='%{preferencesUrl}'>preferences</a>.
       preferences:
         section_head: "Newsletter"
         checkbox_description: "Subscribe to newsletter"

--- a/test/javascripts/acceptance/newsletter-banner-test.js
+++ b/test/javascripts/acceptance/newsletter-banner-test.js
@@ -7,6 +7,7 @@ import {
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import pretender from "discourse/tests/helpers/create-pretender";
+import I18n from "I18n";
 
 acceptance(
   "Discourse Newsletter Integration - Newsletter Banner - Anons",
@@ -60,18 +61,6 @@ acceptance(
       );
     });
 
-    test("manage preferences link", async function (assert) {
-      await visit("/");
-
-      const managePreferencesLink = query(
-        ".newsletter-subscription-banner .manage-preferences"
-      );
-      assert.ok(
-        managePreferencesLink.href.endsWith("/my/preferences/emails"),
-        "manage preferences link has href to `/my/preferences/emails`"
-      );
-    });
-
     test("dismiss button when clicked and the HTTP request succeeds", async function (assert) {
       let deleteRequestSent = false;
 
@@ -121,13 +110,37 @@ acceptance(
       });
 
       await visit("/");
+
+      assert
+        .dom(".newsletter-subscription-banner .banner-text")
+        .includesText(
+          I18n.t("discourse_newsletter_integration.banner.heading"),
+          "banner has text to prompt the user to subscribe"
+        );
+
       await click(".newsletter-subscription-banner .subscribe-btn");
 
       assert.ok(postRequestSent, "sends a HTTP request to subscribe the user");
-      assert.notOk(
-        exists(".newsletter-subscription-banner"),
-        "banner is no longer visible"
+      assert
+        .dom(".newsletter-subscription-banner .banner-text")
+        .includesText(
+          I18n.t("discourse_newsletter_integration.banner.thank_you"),
+          "banner displays a message to indicate that the user has been subscribed"
+        );
+
+      const preferencesLink = query(
+        ".newsletter-subscription-banner .banner-description a"
       );
+      assert.ok(
+        preferencesLink.href.endsWith("/my/preferences/emails"),
+        "there's a link to preferences"
+      );
+
+      await click(".newsletter-subscription-banner .close-btn");
+
+      assert
+        .dom(".newsletter-subscription-banner")
+        .doesNotExist("clicking the dismiss closes the banner");
     });
 
     test("subscribe button when clicked but the HTTP request fails", async function (assert) {


### PR DESCRIPTION
Currently, when a user subscribes to the newsletter via the banner at top of the site, the banner disappears as soon as the subscribe button is clicked. This behavior isn't ideal from a UX perspective because there's no confirmation that the user action has done anything.

This PR improves the subscribe UX by displaying a confirmation message after the user clicks the subscribe button. It also moves the 'Manage preferences' link from the initial banner state to the confirmation message.

Screenshot of the confirmation message:

![image](https://github.com/discourse/discourse-newsletter-integration/assets/17474474/35fe7f7a-cacb-43e7-a801-c7f7553e461d)

Internal topic: t/96002/31.