### PR TITLE
FIX: Skip CSRF and login-required checks for webhook endpoints

### DIFF
--- a/app/controllers/newsletter_integration/webhooks/mailchimp_controller.rb
+++ b/app/controllers/newsletter_integration/webhooks/mailchimp_controller.rb
@@ -8,7 +8,7 @@ module NewsletterIntegration
     requires_plugin NewsletterIntegration::PLUGIN_NAME
 
     before_action :verify_shared_secret
-    skip_before_action :check_xhr
+    skip_before_action :check_xhr, :redirect_to_login_if_required, :verify_authenticity_token
 
     rescue_from BadSecret do
       render body: "not ok", status: 404

--- a/spec/requests/newsletter_integration/webhooks/mailchimp_controller_spec.rb
+++ b/spec/requests/newsletter_integration/webhooks/mailchimp_controller_spec.rb
@@ -49,9 +49,20 @@ describe NewsletterIntegration::Webhooks::MailchimpController do
       get "/newsletter-integration/webhooks/mailchimp/#{webhook_secret}"
       expect(response.status).to eq(200)
     end
+
+    it "responds with 200 when the loging_required setting is enabled" do
+      SiteSetting.login_required = true
+
+      get "/newsletter-integration/webhooks/mailchimp/#{webhook_secret}"
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "#sync" do
+    before { ActionController::Base.allow_forgery_protection = true }
+
+    after { ActionController::Base.allow_forgery_protection = false }
+
     context "when the plugin is disabled" do
       before { SiteSetting.discourse_newsletter_integration_enabled = false }
 


### PR DESCRIPTION
We don't need to check CSRF tokens for webhook requests because they're sent programmatically by external applications/services where there's no authenticated user and no possibility to forge a request.

Similarly, webhook requests should be allowed to go through even when the site is login-required because they're expected to be sent as unauthenticated requests (no current user) and they can only perform a specific action with no way to exfiltrate arbitrary data from the site.