### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.4.0.beta2-dev: 1b08ff008ef9b93740395f711ee8d36469baa672
 < 3.4.0.beta1-dev: 4bac305f75e10e2e921d0cbc32f0e413cfd36160
 < 3.3.0.beta1-dev: b1111aaa0bb6da0cfa8ccc4dceae3ebc7b826b45

--- a/assets/javascripts/discourse/connectors/top-notices/newsletter-banner.hbs
+++ b/assets/javascripts/discourse/connectors/top-notices/newsletter-banner.hbs
@@ -21,7 +21,7 @@
       {{/if}}
     </div>
     <div class="banner-controls">
-      <DButton @icon="times" @action={{action "dismiss"}} class="close-btn" />
+      <DButton @icon="xmark" @action={{action "dismiss"}} class="close-btn" />
       {{#unless this.subscribed}}
         <DButton
           @label="discourse_newsletter_integration.banner.subscribe"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.